### PR TITLE
Refactor simplify

### DIFF
--- a/V1/code/Multi007/Multi007.ino
+++ b/V1/code/Multi007/Multi007.ino
@@ -1,31 +1,28 @@
-int pot[6] {};
+int pot[6]{};
 
 struct {
-    int prev {};
-    int chg {};
-} pots [3];
+  int prev{};
+  int chg{};
+} pots[3];
 
-struct position{
-    int flag {};
-    const long value {};
+struct position {
+  int flag{};
+  const long value{};
 
-    position(long v)
-     : value { v }
-     {}
+  position(long v) : value{v} {}
 
-} pos [3] {{16000}, {0}, {-16000}};
+} pos[3]{{16000}, {0}, {-16000}};
 
+int diff[3]{};
 
-int diff[3] {};
-
-int biggest {};
+int biggest{};
 
 // wheel encoder interrupts
 
-constexpr int encoder0PinA { 2 };
-constexpr int encoder0PinB { 3 };
+constexpr int encoder0PinA{2};
+constexpr int encoder0PinB{3};
 
-volatile long encoder0Pos = 0;    // encoder 1
+volatile long encoder0Pos = 0; // encoder 1
 long encoder0Target = 0;
 long encoderDiff = 0;
 
@@ -46,150 +43,144 @@ inline bool check_difference(int i) {
          ((i == 2) || ((target - abs(diff[2])) > 10));
 }
 
-
-inline int encoder_parity()
-{
-    if (digitalRead(encoder0PinA) == digitalRead(encoder0PinB)) {
-        return 1;
-    }
-    return -1;
+inline int encoder_parity() {
+  if (digitalRead(encoder0PinA) == digitalRead(encoder0PinB)) {
+    return 1;
+  }
+  return -1;
 }
 
-void doEncoderA() {
-    encoder0Pos += - encoder_parity();
-}
+void doEncoderA() { encoder0Pos += -encoder_parity(); }
 
-void doEncoderB() {
-    encoder0Pos += encoder_parity();
-}
+void doEncoderB() { encoder0Pos += encoder_parity(); }
 
 void setup() {
 
-    pinMode(encoder0PinA, INPUT_PULLUP);    // encoder pins
-    pinMode(encoder0PinB, INPUT_PULLUP);
+  pinMode(encoder0PinA, INPUT_PULLUP); // encoder pins
+  pinMode(encoder0PinB, INPUT_PULLUP);
 
-    attachInterrupt(0, doEncoderA, CHANGE);
-    attachInterrupt(1, doEncoderB, CHANGE);
+  attachInterrupt(0, doEncoderA, CHANGE);
+  attachInterrupt(1, doEncoderB, CHANGE);
 
-    pinMode(A0, INPUT);
-    pinMode(A1, INPUT);
-    pinMode(A2, INPUT);
-    pinMode(A3, INPUT);
-    pinMode(A4, INPUT);
-    pinMode(A5, INPUT);
+  pinMode(A0, INPUT);
+  pinMode(A1, INPUT);
+  pinMode(A2, INPUT);
+  pinMode(A3, INPUT);
+  pinMode(A4, INPUT);
+  pinMode(A5, INPUT);
 
-    pinMode(4, OUTPUT);
-    pinMode(5, OUTPUT);
-    pinMode(6, OUTPUT);
-    pinMode(7, OUTPUT);
-  
-    Serial.begin(115200);
+  pinMode(4, OUTPUT);
+  pinMode(5, OUTPUT);
+  pinMode(6, OUTPUT);
+  pinMode(7, OUTPUT);
+
+  Serial.begin(115200);
 }
 
 void loop() {
 
   currentMillis = millis();
 
-    if (currentMillis - previousMillis >= 10) {  // start timed loop
-          previousMillis = currentMillis;
+  if (currentMillis - previousMillis >= 10) { // start timed loop
+    previousMillis = currentMillis;
 
-          pot[0] = analogRead(A0);
-          pot[0] = map(pot[0],0,1023,1023,0);
-          pot[1] = analogRead(A1);
-          pot[1] = map(pot[1],0,1023,1023,0);
-          pot[2] = analogRead(A2);
-          pot[2] = map(pot[2],0,1023,1023,0);
-          pot[3] = analogRead(A3);
-          pot[4] = analogRead(A4);
-          pot[5] = analogRead(A5);
+    pot[0] = analogRead(A0);
+    pot[0] = map(pot[0], 0, 1023, 1023, 0);
+    pot[1] = analogRead(A1);
+    pot[1] = map(pot[1], 0, 1023, 1023, 0);
+    pot[2] = analogRead(A2);
+    pot[2] = map(pot[2], 0, 1023, 1023, 0);
+    pot[3] = analogRead(A3);
+    pot[4] = analogRead(A4);
+    pot[5] = analogRead(A5);
 
-          diff[0] = pot[0] - pot[3];
-          diff[1] = pot[1] - pot[4];
-          diff[2] = pot[2] - pot[5];
+    diff[0] = pot[0] - pot[3];
+    diff[1] = pot[1] - pot[4];
+    diff[2] = pot[2] - pot[5];
 
-          // work out which error is the biggest with some deadspot
+    // work out which error is the biggest with some deadspot
 
-            for (int i{0}; i < 3; i++) {
-                if (check_difference(i)) {
-                    if (((i == 0) || check_flag(0)) && ((i == 1) || check_flag(1)) &&
-                        ((i == 2) || check_flag(2))) {
-                    pos[i].flag = 1;
-                    biggest = i;
-                    encoder0Target = pos[i].value; // move linear axis
-                    }
-                    break;
-                }
-            }
-
-          // check if demand positions have changed since the last loop
-          // I am running this slower so there are bigger changes in the pots on each cycle of the loop when I am moving them
-
-          if (currentMillis - previousPotMillis >= 100) {  // start timed loop
-            previousPotMillis = currentMillis;
-
-            for (int i{0}; i < 3; i++) {
-                pots[i].chg = (pot[i] == pots[i].prev) ? 0 : 1;
-                pots[i].prev = pot[i];
-            }
-
-          }
-
-          // serial debug
-
-          Serial.print("  zero:  ");
-          Serial.print(diff[0]);
-          Serial.print("  one:  ");
-          Serial.print(diff[1]);
-          Serial.print("  two:  ");
-          Serial.print(diff[2]);
-          Serial.print("     biggest is: ");
-          Serial.print(biggest);
-          Serial.print("   ");    
-          Serial.print(pots[1].chg);
-          Serial.print("   ");      
-
-          // check if the linear axis got to the target yet
-          encoderDiff = abs(encoder0Target - encoder0Pos);
-          if (encoderDiff < 300) {    // if we got to the target then move the motor that drives the worm gears
-            for (int i{0}; i < 3; i++) {
-                if (biggest != i) {
-                    continue;
-                }
-                Serial.print("arrived at 0");
-                if (diff[i] > 0 + 20) {
-                    analogWrite(6, 255);
-                    analogWrite(7, 0);
-                } else if (diff[i] < 0 - 20) {
-                    analogWrite(6, 0);
-                    analogWrite(7, 255);
-                } else {
-                    analogWrite(6, 0);
-                    analogWrite(7, 0);
-                    pos[i].flag = 0;
-                }
-                break;
-            }
-          }
-          
-          Serial.println();      
-          
-          // drive linear axis
-
-          if (encoder0Target < encoder0Pos - 250) {   // allow for a deadzone of 250 encoder counts
-              analogWrite(5, 255);
-              analogWrite(4, 0);
-          }
-          else if (encoder0Target > encoder0Pos + 250) {   // allow for a deadzone of 250 encoder counts
-              analogWrite(5, 0);
-              analogWrite(4, 255);
-          }
-
-          else {
-            analogWrite(4, 0);
-            analogWrite(5, 0);
-          }       
-         
+    for (int i{0}; i < 3; i++) {
+      if (check_difference(i)) {
+        if (((i == 0) || check_flag(0)) && ((i == 1) || check_flag(1)) &&
+            ((i == 2) || check_flag(2))) {
+          pos[i].flag = 1;
+          biggest = i;
+          encoder0Target = pos[i].value; // move linear axis
+        }
+        break;
+      }
     }
 
-}
+    // check if demand positions have changed since the last loop
+    // I am running this slower so there are bigger changes in the pots on each
+    // cycle of the loop when I am moving them
 
+    if (currentMillis - previousPotMillis >= 100) { // start timed loop
+      previousPotMillis = currentMillis;
+
+      for (int i{0}; i < 3; i++) {
+        pots[i].chg = (pot[i] == pots[i].prev) ? 0 : 1;
+        pots[i].prev = pot[i];
+      }
+    }
+
+    // serial debug
+
+    Serial.print("  zero:  ");
+    Serial.print(diff[0]);
+    Serial.print("  one:  ");
+    Serial.print(diff[1]);
+    Serial.print("  two:  ");
+    Serial.print(diff[2]);
+    Serial.print("     biggest is: ");
+    Serial.print(biggest);
+    Serial.print("   ");
+    Serial.print(pots[1].chg);
+    Serial.print("   ");
+
+    // check if the linear axis got to the target yet
+    encoderDiff = abs(encoder0Target - encoder0Pos);
+    if (encoderDiff < 300) { // if we got to the target then move the motor that
+                             // drives the worm gears
+      for (int i{0}; i < 3; i++) {
+        if (biggest != i) {
+          continue;
+        }
+        Serial.print("arrived at 0");
+        if (diff[i] > 0 + 20) {
+          analogWrite(6, 255);
+          analogWrite(7, 0);
+        } else if (diff[i] < 0 - 20) {
+          analogWrite(6, 0);
+          analogWrite(7, 255);
+        } else {
+          analogWrite(6, 0);
+          analogWrite(7, 0);
+          pos[i].flag = 0;
+        }
+        break;
+      }
+    }
+
+    Serial.println();
+
+    // drive linear axis
+
+    if (encoder0Target <
+        encoder0Pos - 250) { // allow for a deadzone of 250 encoder counts
+      analogWrite(5, 255);
+      analogWrite(4, 0);
+    } else if (encoder0Target >
+               encoder0Pos +
+                   250) { // allow for a deadzone of 250 encoder counts
+      analogWrite(5, 0);
+      analogWrite(4, 255);
+    }
+
+    else {
+      analogWrite(4, 0);
+      analogWrite(5, 0);
+    }
+  }
+}

--- a/V1/code/Multi007/Multi007.ino
+++ b/V1/code/Multi007/Multi007.ino
@@ -47,6 +47,22 @@ inline bool check_difference(int i) {
 }
 
 
+inline int encoder_parity()
+{
+    if (digitalRead(encoder0PinA) == digitalRead(encoder0PinB)) {
+        return 1;
+    }
+    return -1;
+}
+
+void doEncoderA() {
+    encoder0Pos += - encoder_parity();
+}
+
+void doEncoderB() {
+    encoder0Pos += encoder_parity();
+}
+
 void setup() {
 
     pinMode(encoder0PinA, INPUT_PULLUP);    // encoder pins
@@ -177,18 +193,3 @@ void loop() {
 
 }
 
-inline int encoder_parity()
-{
-    if (digitalRead(encoder0PinA) == digitalRead(encoder0PinB)) {
-        return 1;
-    }
-    return -1;
-}
-
-void doEncoderA() {
-    encoder0Pos += - encoder_parity();
-}
-
-void doEncoderB() {
-    encoder0Pos += encoder_parity();
-}

--- a/V1/code/Multi007/Multi007.ino
+++ b/V1/code/Multi007/Multi007.ino
@@ -22,8 +22,8 @@ int biggest {};
 
 // wheel encoder interrupts
 
-#define encoder0PinA 2      // encoder 1
-#define encoder0PinB 3
+constexpr int encoder0PinA { 2 };
+constexpr int encoder0PinB { 3 };
 
 volatile long encoder0Pos = 0;    // encoder 1
 long encoder0Target = 0;

--- a/V1/code/Multi007/Multi007.ino
+++ b/V1/code/Multi007/Multi007.ino
@@ -1,27 +1,24 @@
-int pot0;     // actual 0
-int pot1;     // actual 1
-int pot2;     // actual 2
-int pot3;     // demand 0
-int pot4;     // demand 1
-int pot5;     // demand 2
+int pot[6] {};
 
-int pot0Prev;
-int pot1Prev;
-int pot2Prev;
+struct {
+    int prev {};
+    int chg {};
+} pots [3];
 
-int pot0chg = 0;
-int pot1chg = 0;
-int pot2chg = 0;
+struct position{
+    int flag {};
+    const long value {};
 
-int diff0;    // difference 0
-int diff1;    // difference 1
-int diff2;    // difference 2
+    position(long v)
+     : value { v }
+     {}
 
-int pos0Flag = 0;
-int pos1Flag = 0;
-int pos2Flag = 0;
+} pos [3] {{16000}, {0}, {-16000}};
 
-int biggest;
+
+int diff[3] {};
+
+int biggest {};
 
 // wheel encoder interrupts
 
@@ -68,41 +65,41 @@ void loop() {
     if (currentMillis - previousMillis >= 10) {  // start timed loop
           previousMillis = currentMillis;
 
-          pot0 = analogRead(A0);
-          pot0 = map(pot0,0,1023,1023,0);
-          pot1 = analogRead(A1);
-          pot1 = map(pot1,0,1023,1023,0);
-          pot2 = analogRead(A2);
-          pot2 = map(pot2,0,1023,1023,0);
-          pot3 = analogRead(A3);
-          pot4 = analogRead(A4);
-          pot5 = analogRead(A5);
+          pot[0] = analogRead(A0);
+          pot[0] = map(pot[0],0,1023,1023,0);
+          pot[1] = analogRead(A1);
+          pot[1] = map(pot[1],0,1023,1023,0);
+          pot[2] = analogRead(A2);
+          pot[2] = map(pot[2],0,1023,1023,0);
+          pot[3] = analogRead(A3);
+          pot[4] = analogRead(A4);
+          pot[5] = analogRead(A5);
 
-          diff0 = pot0 - pot3;
-          diff1 = pot1 - pot4;
-          diff2 = pot2 - pot5;
+          diff[0] = pot[0] - pot[3];
+          diff[1] = pot[1] - pot[4];
+          diff[2] = pot[2] - pot[5];
 
           // work out which error is the biggest with some deadspot
 
-          if (abs(diff0) > (abs(diff1)+10) && abs(diff0) > (abs(diff2)+10)) {
-              if (pos1Flag == 0 && pos2Flag == 0 && pot1chg == 0 && pot2chg == 0) {
-                pos0Flag = 1;
+          if (abs(diff[0]) > (abs(diff[1])+10) && abs(diff[0]) > (abs(diff[2])+10)) {
+              if (pos[1].flag == 0 && pos[2].flag == 0 && pots[1].chg == 0 && pots[2].chg == 0) {
+                pos[0].flag = 1;
                 biggest = 0;
-                encoder0Target = 16000;   // move linear axis
+                encoder0Target = pos[0].value;   // move linear axis
               }
           }
-          else if (abs(diff1) > (abs(diff0)+10) && abs(diff1) > (abs(diff2)+10)) {
-              if (pos0Flag == 0 && pos2Flag == 0 && pot0chg == 0 && pot2chg == 0) {
-                pos1Flag = 1;
+          else if (abs(diff[1]) > (abs(diff[0])+10) && abs(diff[1]) > (abs(diff[2])+10)) {
+              if (pos[0].flag == 0 && pos[2].flag == 0 && pots[0].chg == 0 && pots[2].chg == 0) {
+                pos[1].flag = 1;
                 biggest = 1;
-                encoder0Target = 0;   // move linear axis
+                encoder0Target = pos[1].value;   // move linear axis
               }
           }
-          else if (abs(diff2) > (abs(diff0)+10) && abs(diff2) > (abs(diff1)+10)) {
-              if (pos0Flag == 0 && pos1Flag == 0 && pot0chg == 0 && pot1chg == 0) {
-                pos2Flag = 1;
+          else if (abs(diff[2]) > (abs(diff[0])+10) && abs(diff[2]) > (abs(diff[1])+10)) {
+              if (pos[0].flag == 0 && pos[1].flag == 0 && pots[0].chg == 0 && pots[1].chg == 0) {
+                pos[2].flag = 1;
                 biggest = 2;
-                encoder0Target = -16000;    // move linear axis
+                encoder0Target = pos[2].value;    // move linear axis
               }
           }
 
@@ -112,41 +109,41 @@ void loop() {
           if (currentMillis - previousPotMillis >= 100) {  // start timed loop
             previousPotMillis = currentMillis;
 
-                if (pot0 == pot0Prev) {
-                    pot0chg = 0;
+                if (pot[0] == pots[0].prev) {
+                    pots[0].chg = 0;
                 }
-                else { pot0chg = 1; }
+                else { pots[0].chg = 1; }
       
-                if (pot1 == pot1Prev) {
-                    pot1chg = 0;
+                if (pot[1] == pots[1].prev) {
+                    pots[1].chg = 0;
                 }
-                else { pot1chg = 1; }
+                else { pots[1].chg = 1; }
       
-                if (pot2 == pot2Prev) {
-                    pot2chg = 0;
+                if (pot[2] == pots[2].prev) {
+                    pots[2].chg = 0;
                 }
-                else { pot2chg = 1; }
+                else { pots[2].chg = 1; }
       
                 // boommark 'previous' values so we can compare them
       
-                pot0Prev = pot0;
-                pot1Prev = pot1;
-                pot2Prev = pot2;
+                pots[0].prev = pot[0];
+                pots[1].prev = pot[1];
+                pots[2].prev = pot[2];
 
           }
 
           // serial debug
 
           Serial.print("  zero:  ");
-          Serial.print(diff0);
+          Serial.print(diff[0]);
           Serial.print("  one:  ");
-          Serial.print(diff1);
+          Serial.print(diff[1]);
           Serial.print("  two:  ");
-          Serial.print(diff2);
+          Serial.print(diff[2]);
           Serial.print("     biggest is: ");
           Serial.print(biggest);
           Serial.print("   ");    
-          Serial.print(pot1chg);
+          Serial.print(pots[1].chg);
           Serial.print("   ");      
 
           // check if the linear axis got to the target yet
@@ -155,52 +152,52 @@ void loop() {
             
             if (biggest == 0) {
               Serial.print("arrived at 0");            
-              if (diff0 > 0 + 20) {
+              if (diff[0] > 0 + 20) {
                 analogWrite(6, 255);
                 analogWrite(7, 0);
               }
-              else if (diff0 < 0 - 20){
+              else if (diff[0] < 0 - 20){
                 analogWrite(6, 0);
                 analogWrite(7, 255);
               }
               else {
                 analogWrite(6, 0);
                 analogWrite(7, 0);
-                pos0Flag = 0;
+                pos[0].flag = 0;
               }              
             }
             
             else if (biggest == 1) {
               Serial.print("arived at 1");
-              if (diff1 > 0 + 20) {
+              if (diff[1] > 0 + 20) {
                 analogWrite(6, 255);
                 analogWrite(7, 0);
               }
-              else if (diff1 < 0 - 20){
+              else if (diff[1] < 0 - 20){
                 analogWrite(6, 0);
                 analogWrite(7, 255);
               }
               else {
                 analogWrite(6, 0);
                 analogWrite(7, 0);
-                pos1Flag = 0;
+                pos[1].flag = 0;
               }
             }
             
             else if (biggest == 2) {
               Serial.print("arrived at 2");
-              if (diff2 > 0 + 20){
+              if (diff[2] > 0 + 20){
                 analogWrite(6, 255);
                 analogWrite(7, 0);
               }
-              else if (diff2 < 0 - 20){
+              else if (diff[2] < 0 - 20){
                 analogWrite(6, 0);
                 analogWrite(7, 255);
               }
               else {
                 analogWrite(6, 0);
                 analogWrite(7, 0);
-                pos2Flag = 0;
+                pos[2].flag = 0;
               }
             }
           }

--- a/V1/code/Multi007/Multi007.ino
+++ b/V1/code/Multi007/Multi007.ino
@@ -227,54 +227,18 @@ void loop() {
 
 }
 
-
-void doEncoderA(){  
-
-  // look for a low-to-high on channel A
-  if (digitalRead(encoder0PinA) == HIGH) { 
-    // check channel B to see which way encoder is turning
-    if (digitalRead(encoder0PinB) == LOW) {  
-      encoder0Pos = encoder0Pos + 1;         // CW
-    } 
-    else {
-      encoder0Pos = encoder0Pos - 1;         // CCW
+inline int encoder_parity()
+{
+    if (digitalRead(encoder0PinA) == digitalRead(encoder0PinB)) {
+        return 1;
     }
-  }
-  else   // must be a high-to-low edge on channel A                                       
-  { 
-    // check channel B to see which way encoder is turning  
-    if (digitalRead(encoder0PinB) == HIGH) {   
-      encoder0Pos = encoder0Pos + 1;          // CW
-    } 
-    else {
-      encoder0Pos = encoder0Pos - 1;          // CCW
-    }
-  }
- 
+    return -1;
 }
 
-void doEncoderB(){  
+void doEncoderA() {
+    encoder0Pos += - encoder_parity();
+}
 
-  // look for a low-to-high on channel B
-  if (digitalRead(encoder0PinB) == HIGH) {   
-   // check channel A to see which way encoder is turning
-    if (digitalRead(encoder0PinA) == HIGH) {  
-      encoder0Pos = encoder0Pos + 1;         // CW
-    } 
-    else {
-      encoder0Pos = encoder0Pos - 1;         // CCW
-    }
-  }
-  // Look for a high-to-low on channel B
-  else { 
-    // check channel B to see which way encoder is turning  
-    if (digitalRead(encoder0PinA) == LOW) {   
-      encoder0Pos = encoder0Pos + 1;          // CW
-    } 
-    else {
-      encoder0Pos = encoder0Pos - 1;          // CCW
-    }
-  }
-  
-
+void doEncoderB() {
+    encoder0Pos += encoder_parity();
 }


### PR DESCRIPTION
With this PR, the code is refactored to utilise arrays instead of defining variables with the naming scheme name<number>.

This allows one to use loops instead of duplicating code, which in turn reduces maintenance effort.

**Note that this in untested.**

Also I allowed myself to apply clang-format with style=LLVM to the code.

The changes shouldn't have changed the functionality of the code, though if they do, I will fix this PR accordingly.